### PR TITLE
service worker changed from cache first to network first

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -1,26 +1,32 @@
-const CACHE_NAME = 'vantage-timer-v1';
-const urlsToCache = [
-  '/',
-  '/index.html'
-];
+const CACHE_NAME = "cubeit-v2";
 
-self.addEventListener('install', event => {
-  event.waitUntil(
-    caches.open(CACHE_NAME)
-      .then(cache => {
-        return cache.addAll(urlsToCache);
-      })
-  );
+self.addEventListener("install", event => {
+  self.skipWaiting();
 });
 
-self.addEventListener('fetch', event => {
-  event.respondWith(
-    caches.match(event.request)
-      .then(response => {
-        if (response) {
-          return response; // Return cached version
-        }
-        return fetch(event.request); // Otherwise fetch from network
-      })
+self.addEventListener("activate", event => {
+  event.waitUntil(
+    caches.keys().then(keys =>
+      Promise.all(
+        keys.map(key => {
+          if (key !== CACHE_NAME) {
+            return caches.delete(key);
+          }
+        })
+      )
+    )
   );
+  self.clients.claim();
+});
+
+self.addEventListener("fetch", event => {
+  if (event.request.mode === "navigate") {
+    event.respondWith(
+      fetch(event.request)
+        .then(response => {
+          return response;
+        })
+        .catch(() => caches.match("/index.html"))
+    );
+  }
 });


### PR DESCRIPTION
Initially, the service worker was using a Cache First strategy, which caused the application to keep serving old cached files even after new UI updates were deployed.

Because of this, users continued seeing the old UI unless they performed a hard refresh or manually cleared the cache.

To resolve this issue, the caching strategy was changed from Cache First to Network First for navigation requests. Now the app tries to fetch the latest version from the network first, and only falls back to the cached version when the network is unavailable.

Additionally, old cache versions are automatically deleted, and the new service worker activates immediately using `skipWaiting()` and `clients.claim()`, ensuring users receive updates faster without manual intervention.
