### PR TITLE
feat: add coming soon tags to incomplete sidebar options

### DIFF
--- a/src/SidebarUI.jsx
+++ b/src/SidebarUI.jsx
@@ -39,15 +39,15 @@ function SolveItem({ solve, index, onPenalty, onDelete, isPB }) {
 const NAV_ITEMS = [
   {
     icon: <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M2 3h6a4 4 0 0 1 4 4v14a3 3 0 0 0-3-3H2z"/><path d="M22 3h-6a4 4 0 0 0-4 4v14a3 3 0 0 1 3-3h7z"/></svg>,
-    label: 'Learn CFOP', sub: 'Master the Fridrich method'
+    label: 'Learn CFOP', sub: 'Master the Fridrich method', comingSoon: true
   },
   {
     icon: <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M4 22h16a2 2 0 0 0 2-2V4a2 2 0 0 0-2-2H8a2 2 0 0 0-2 2v2"/><path d="M2 13h6M5 10l3 3-3 3"/></svg>,
-    label: 'Latest News', sub: 'WCA results & community updates'
+    label: 'Latest News', sub: 'WCA results & community updates', comingSoon: true
   },
   {
     icon: <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/><path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"/></svg>,
-    label: 'Blogs', sub: 'Tips, guides & speedsolving'
+    label: 'Blogs', sub: 'Tips, guides & speedsolving', comingSoon: true
   },
   {
     icon: <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg>,
@@ -59,11 +59,11 @@ const NAV_ITEMS = [
   },
   {
     icon: <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="16"/><line x1="8" y1="12" x2="16" y2="12"/></svg>,
-    label: 'Contribute', sub: 'Help build CubeIt', href: 'https://github.com'
+    label: 'Contribute', sub: 'Help build CubeIt', href: 'https://github.com', comingSoon: true
   },
   {
     icon: <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>,
-    label: 'Settings', sub: 'Customize your experience'
+    label: 'Settings', sub: 'Customize your experience', comingSoon: true
   }
 ];
 
@@ -178,18 +178,31 @@ export default function SidebarUI({
           padding: 13px 16px;
           border-radius: 12px;
           cursor: pointer;
-          transition: background 0.15s;
+          transition: background 0.15s, opacity 0.2s;
           text-decoration: none;
           color: inherit;
         }
-        .nav-item:hover { background: rgba(255,255,255,0.06); }
-        .nav-item:hover .nav-arrow { opacity: 1; transform: translateX(0); }
+        .nav-item:not(.disabled):hover { background: rgba(255,255,255,0.06); }
+        .nav-item:not(.disabled):hover .nav-arrow { opacity: 1; transform: translateX(0); }
+        .nav-item.disabled {
+          cursor: default;
+        }
         .nav-arrow {
           margin-left: auto;
           opacity: 0;
           transform: translateX(-4px);
           transition: all 0.2s;
           color: rgba(255,255,255,0.3);
+        }
+        .coming-soon-badge {
+          font-size: 0.65rem;
+          padding: 3px 8px;
+          border-radius: 12px;
+          background: rgba(255,255,255,0.08);
+          color: rgba(255,255,255,0.7);
+          font-weight: 500;
+          border: 0.5px solid rgba(255,255,255,0.15);
+          letter-spacing: 0.5px;
         }
 
         /* Left slide-in panel for history (Desktop) / Bottom drawer (Mobile) */
@@ -377,17 +390,32 @@ export default function SidebarUI({
           {NAV_ITEMS.map((item, idx) => {
             const isExternal = !!item.href;
             const Tag = isExternal ? 'a' : 'div';
-            const extra = isExternal ? { href: item.href, target: '_blank', rel: 'noreferrer' } : {};
+            const isDisabled = !!item.comingSoon;
+            const extra = isExternal && !isDisabled ? { href: item.href, target: '_blank', rel: 'noreferrer' } : {};
+            
             return (
-              <Tag key={idx} className="nav-item" {...extra}>
+              <Tag 
+                key={idx} 
+                className={`nav-item ${isDisabled ? 'disabled' : ''}`} 
+                {...extra}
+                onClick={(e) => {
+                  if (isDisabled) e.preventDefault();
+                }}
+                title={item.comingSoon ? 'Coming Soon' : ''}
+              >
                 <div style={{ color: 'rgba(255,255,255,0.45)', flexShrink: 0 }}>{item.icon}</div>
-                <div>
-                  <div style={{ fontSize: '0.95rem', fontWeight: '600', color: 'rgba(255,255,255,0.9)' }}>{item.label}</div>
+                <div style={{ flex: 1 }}>
+                  <div style={{ fontSize: '0.95rem', fontWeight: '600', color: 'rgba(255,255,255,0.9)', display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+                    <span>{item.label}</span>
+                    {item.comingSoon && <span className="coming-soon-badge">Coming Soon</span>}
+                  </div>
                   <div style={{ fontSize: '0.72rem', color: 'rgba(255,255,255,0.35)', marginTop: '2px' }}>{item.sub}</div>
                 </div>
-                <span className="nav-arrow">
-                  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="M9 18l6-6-6-6" /></svg>
-                </span>
+                {!isDisabled && (
+                  <span className="nav-arrow">
+                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="M9 18l6-6-6-6" /></svg>
+                  </span>
+                )}
               </Tag>
             );
           })}


### PR DESCRIPTION
<img width="1915" height="873" alt="image" src="https://github.com/user-attachments/assets/bc258dfa-50f4-4c1e-8e2c-2f97062bc406" />

Description
This PR updates the sidebar navigation to clearly communicate which features are still in development, preventing user confusion from dead clicks.

Changes Made:
- Added "Coming Soon" badges to Learn CFOP, Latest News, Blogs, Contribute, and Settings.
- Disabled click events (e.preventDefault()) on all "Coming Soon" items.
- Added native hover tooltips (title="Coming Soon") for accessibility.
- Removed hover-state arrow icons from inactive items so they no longer appear clickable.
- Note: About Us and Star on GitHub were intentionally left active per maintainer feedback.

Fixes #15  