### PR TITLE
style: add custom favicon to browser tab

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="utf-8" />
@@ -10,6 +10,7 @@
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <link rel="manifest" href="/manifest.json" />
+    <link rel="icon" type="image/png" href="cube-icon.png" />
     <title>CUBEIT — Speedcubing Timer</title>
   </head>
 
@@ -19,12 +20,15 @@
     <script>
       if ('serviceWorker' in navigator) {
         window.addEventListener('load', () => {
-          navigator.serviceWorker.register('/sw.js').then(registration => {
-            console.log('SW registered: ', registration);
-          }).catch(registrationError => {
-            console.log('SW registration failed: ', registrationError);
-          });
-        });
+          navigator.serviceWorker
+            .register('/sw.js')
+            .then((registration) => {
+              console.log('SW registered: ', registration)
+            })
+            .catch((registrationError) => {
+              console.log('SW registration failed: ', registrationError)
+            })
+        })
       }
     </script>
   </body>


### PR DESCRIPTION
Closes #35 

## What’s Added
- Linked the existing favicon(CubeIt official logo) inside the HTML head.
## Purpose
This fixes the missing favicon issue, ensuring the custom speedcubing timer icon displays correctly in the browser tab instead of showing a blank default page icon.

## Checklist
- [x] My code follows the repository's formatting style.
- [x] Tested changes locally using `npm start`.
- [x] No console errors or breaks in application logic.