### PR TITLE
[Feature]: Fix Star on GitHub sidebar link

### DIFF
--- a/src/SidebarUI.jsx
+++ b/src/SidebarUI.jsx
@@ -55,7 +55,7 @@ const NAV_ITEMS = [
   },
   {
     icon: <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"/></svg>,
-    label: 'Star on GitHub', sub: 'Support the open-source project', href: 'https://github.com'
+    label: 'Star on GitHub', sub: 'Support the open-source project', href: 'https://github.com/vasanth642/CubeIt'
   },
   {
     icon: <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="16"/><line x1="8" y1="12" x2="16" y2="12"/></svg>,


### PR DESCRIPTION
## Summary
- Updated the sidebar **Star on GitHub** option to link directly to the official CubeIt repository.
- Removed the need for a separate “Star on GitHub” page by redirecting users straight to GitHub.

## Fixes
Fixes #2

## Testing
- Verified that clicking **Star on GitHub** in the sidebar opens:
  https://github.com/vasanth642/CubeIt